### PR TITLE
Making compatible with Polylang

### DIFF
--- a/includes/wc-page-functions.php
+++ b/includes/wc-page-functions.php
@@ -57,6 +57,8 @@ function wc_get_page_id( $page ) {
 	}
 
 	$page = apply_filters( 'woocommerce_get_' . $page . '_page_id', get_option( 'woocommerce_' . $page . '_page_id' ) );
+	
+	do_action( 'wc_polylang_page' );
 
 	return $page ? absint( $page ) : -1;
 }


### PR DESCRIPTION
For polylang, it $page should be.

$page = function_exists('pll_get_post') ? apply_filters( 'woocommerce_get_' . $page . '_page_id', pll_get_post ( get_option('woocommerce_' . $page . '_page_id' ) ) ) : apply_filters( 'woocommerce_get_' . $page . '_page_id', get_option('woocommerce_' . $page . '_page_id' ) );

now we can use "wc_polylang_page" hook to override $page variable.
